### PR TITLE
static link of threading libraries

### DIFF
--- a/pm_kext_glue_dll/pm_kext_glue_dll.vcxproj
+++ b/pm_kext_glue_dll/pm_kext_glue_dll.vcxproj
@@ -166,6 +166,7 @@
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <AdditionalIncludeDirectories>$(SolutionDir)\include;$(ProjectDir)\include</AdditionalIncludeDirectories>
       <LanguageStandard_C>stdc11</LanguageStandard_C>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/pm_kext_glue_dll/src/pm_kernel_glue.c
+++ b/pm_kext_glue_dll/src/pm_kernel_glue.c
@@ -57,7 +57,7 @@ static HMODULE module = NULL;
 /*
  * Dll Entry
  */
-extern bool APIENTRY portmasterDllEntry(HANDLE module0, DWORD reason, LPVOID reserved) {
+extern _EXPORT bool APIENTRY portmasterDllEntry(HANDLE module0, DWORD reason, LPVOID reserved) {
     HANDLE event = INVALID_HANDLE_VALUE;
     switch (reason) {
         case DLL_PROCESS_ATTACH:


### PR DESCRIPTION
The new build system was linking dll that are not installed on every pc. If they are missing Portmaster is not able to load the glue dll.

The changes remove does dependencies .