### PR TITLE
Fix memory leaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,12 @@ Enable Test Signing on the dev machine:
     Bcdedit.exe -set TESTSIGNING ON
     :: Then, restart Windows. For more information, see The TESTSIGNING Boot Configuration Option.
 
+__Debugging__
+
+Monitor memory usage with:
+
+    "C:\Program Files (x86)\Windows Kits\10\Tools\10.0.22621.0\x64\poolmon.exe" /iPMas
+
 ### Releasing
 
 Please check the `release` directory for further information on releasing the Portmaster Kernel Extension.

--- a/deploy.bat
+++ b/deploy.bat
@@ -1,5 +1,5 @@
 echo Compile, Sign and Copy the Kernel Driver
-set WDDK_SOURCE=install\WDDK\x64\Debug\pm_kernel64.sys
+set WDDK_SOURCE=install\WDDK\x64\Debug\pm_kernel_x64.sys
 del %WDDK_SOURCE%
 
 msbuild /t:Clean /p:Configuration=Debug /p:Platform=x64 portmaster-windows-kext.sln

--- a/pm_kext/pm_kext.vcxproj
+++ b/pm_kext/pm_kext.vcxproj
@@ -91,13 +91,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <DebuggerFlavor>DbgengKernelDebugger</DebuggerFlavor>
     <OutDir>$(SolutionDir)install\WDDK\$(Platform)\$(ConfigurationName)\</OutDir>
-    <TargetName>pm_kernel64</TargetName>
+    <TargetName>pm_kernel_x64</TargetName>
     <EnableInf2cat>false</EnableInf2cat>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <DebuggerFlavor>DbgengKernelDebugger</DebuggerFlavor>
     <OutDir>$(SolutionDir)install\WDDK\$(Platform)\$(ConfigurationName)\</OutDir>
-    <TargetName>pm_kernel64</TargetName>
+    <TargetName>pm_kernel_x64</TargetName>
     <EnableInf2cat>false</EnableInf2cat>
     <RunCodeAnalysis>true</RunCodeAnalysis>
     <EnableClangTidyCodeAnalysis>false</EnableClangTidyCodeAnalysis>

--- a/pm_kext/src/pm_callouts.c
+++ b/pm_kext/src/pm_callouts.c
@@ -1043,9 +1043,10 @@ void classifyALEOutboundIPv4(
     UINT64 flowContext,
     FWPS_CLASSIFY_OUT* classifyOut) {
 
-    UNREFERENCED_PARAMETER(flowContext);
-    UNREFERENCED_PARAMETER(filter);
+    UNREFERENCED_PARAMETER(layerData);
     UNREFERENCED_PARAMETER(classifyContext);
+    UNREFERENCED_PARAMETER(filter);
+    UNREFERENCED_PARAMETER(flowContext);
     UNREFERENCED_PARAMETER(classifyOut);
 
     // Sanity check 2
@@ -1086,11 +1087,6 @@ void classifyALEOutboundIPv4(
     // Set flag to notify userspace that this is a socket authentication packet.
     packetInfo->flags |= PM_STATUS_SOCKET_AUTH;
 
-    if(wasPacketInjected(packetInfo, layerData)) {
-        portmasterFree(packetInfo);
-        return;
-    }
-
     INFO("connection ALE layer process ID: %d", packetInfo->processID);
 
     // Allocate queue entry and copy packetInfo
@@ -1114,9 +1110,10 @@ void classifyALEInboundIPv4(
     UINT64 flowContext,
     FWPS_CLASSIFY_OUT* classifyOut) {
 
-    UNREFERENCED_PARAMETER(flowContext);
-    UNREFERENCED_PARAMETER(filter);
+    UNREFERENCED_PARAMETER(layerData);
     UNREFERENCED_PARAMETER(classifyContext);
+    UNREFERENCED_PARAMETER(filter);
+    UNREFERENCED_PARAMETER(flowContext);
     UNREFERENCED_PARAMETER(classifyOut);
 
     // Sanity check 2
@@ -1157,11 +1154,6 @@ void classifyALEInboundIPv4(
     // Set flag to notify userspace that this is a socket authentication packet.
     packetInfo->flags |= PM_STATUS_SOCKET_AUTH;
 
-    if(wasPacketInjected(packetInfo, layerData)) {
-        portmasterFree(packetInfo);
-        return;
-    }
-
     INFO("connection ALE layer process ID: %d", packetInfo->processID);
 
     // Allocate queue entry and copy packetInfo
@@ -1185,9 +1177,10 @@ void classifyALEOutboundIPv6(
     UINT64 flowContext,
     FWPS_CLASSIFY_OUT* classifyOut) {
 
-    UNREFERENCED_PARAMETER(flowContext);
-    UNREFERENCED_PARAMETER(filter);
+    UNREFERENCED_PARAMETER(layerData);
     UNREFERENCED_PARAMETER(classifyContext);
+    UNREFERENCED_PARAMETER(filter);
+    UNREFERENCED_PARAMETER(flowContext);
     UNREFERENCED_PARAMETER(classifyOut);
 
     // Sanity check
@@ -1238,11 +1231,6 @@ void classifyALEOutboundIPv6(
     // Set flag to notify userspace that this is a socket authentication packet.
     packetInfo->flags |= PM_STATUS_SOCKET_AUTH;
 
-    if(wasPacketInjected(packetInfo, layerData)) {
-        portmasterFree(packetInfo);
-        return;
-    }
-
     INFO("connection ALE layer process ID: %d", packetInfo->processID);
 
     // Allocate queue entry and copy packetInfo
@@ -1266,9 +1254,10 @@ void classifyALEInboundIPv6(
     UINT64 flowContext,
     FWPS_CLASSIFY_OUT* classifyOut) {
 
-    UNREFERENCED_PARAMETER(flowContext);
-    UNREFERENCED_PARAMETER(filter);
+    UNREFERENCED_PARAMETER(layerData);
     UNREFERENCED_PARAMETER(classifyContext);
+    UNREFERENCED_PARAMETER(filter);
+    UNREFERENCED_PARAMETER(flowContext);
     UNREFERENCED_PARAMETER(classifyOut);
 
     // Sanity check
@@ -1319,11 +1308,6 @@ void classifyALEInboundIPv6(
 
     // Set flag to notify userspace that this is a socket authentication packet.
     packetInfo->flags |= PM_STATUS_SOCKET_AUTH;
-
-    if(wasPacketInjected(packetInfo, layerData)) {
-        portmasterFree(packetInfo);
-        return;
-    }
 
     INFO("connection ALE layer process ID: %d", packetInfo->processID);
 

--- a/pm_kext/src/pm_kernel.c
+++ b/pm_kext/src/pm_kernel.c
@@ -352,6 +352,11 @@ NTSTATUS driverDeviceControl(__in PDEVICE_OBJECT pDeviceObject, __inout PIRP Irp
                 Irp->IoStatus.Information = size;
                 IoCompleteRequest(Irp, IO_NO_INCREMENT);
 
+                if(dentry->packet->processID != 0) {
+                    // Packet comes from the ALE layer and it's not saved in cache. It's not needed anymore.
+                    portmasterFree(dentry->packet);
+                }
+
                 // Now that the contents of the list-entry is copied, free memory
                 portmasterFree(dentry);
                 return STATUS_SUCCESS;

--- a/pm_kext/src/pm_kernel.c
+++ b/pm_kext/src/pm_kernel.c
@@ -352,7 +352,7 @@ NTSTATUS driverDeviceControl(__in PDEVICE_OBJECT pDeviceObject, __inout PIRP Irp
                 Irp->IoStatus.Information = size;
                 IoCompleteRequest(Irp, IO_NO_INCREMENT);
 
-                if(dentry->packet->processID != 0) {
+                if ((dentry->packet->flags & PM_STATUS_SOCKET_AUTH) > 0) {
                     // Packet comes from the ALE layer and it's not saved in cache. It's not needed anymore.
                     portmasterFree(dentry->packet);
                 }

--- a/pm_kext/src/pm_packet.c
+++ b/pm_kext/src/pm_packet.c
@@ -451,7 +451,7 @@ static NTSTATUS sendICMPBlockedPacket(PortmasterPacketInfo* packetInfo, void *or
     if(useLocalHost) {
         injectDirection = DIRECTION_OUTBOUND;
     }
-    NTSTATUS status = injectPacketWithHandle(handle, packetInfo, injectDirection, icmpPacket, packetLength);
+    NTSTATUS status = injectPacketWithHandle(handle, packetInfo, injectDirection, icmpPacket, packetLength); // this call will free the packet even if the inject fails
     if (!NT_SUCCESS(status)) {
         ERR("sendICMPBlockedPacket -> FwpsInjectNetworkSendAsync or FwpsInjectNetworkReceiveAsync returned %d", status);
     }

--- a/release/release_prepackage.bat
+++ b/release/release_prepackage.bat
@@ -20,8 +20,8 @@ echo.
 echo =====
 echo copying files ...
 mkdir %CABDIR%\amd64
-copy %INSTALL_WDDK_AMD64%\pm_kernel64.sys %CABDIR%\amd64\PortmasterKext64.sys
-copy %INSTALL_WDDK_AMD64%\pm_kernel64.pdb %CABDIR%\amd64\PortmasterKext64.pdb
+copy %INSTALL_WDDK_AMD64%\pm_kernel_x64.sys %CABDIR%\amd64\PortmasterKext64.sys
+copy %INSTALL_WDDK_AMD64%\pm_kernel_x64.pdb %CABDIR%\amd64\PortmasterKext64.pdb
 copy %INSTALL_WDDK_AMD64%\PortmasterKext64.inf %CABDIR%\amd64\PortmasterKext64.inf
 copy %CABDIR%\amd64\PortmasterKext64.pdb %DISTDIR%\portmaster-kext_vX-X-X.pdb
 echo.


### PR DESCRIPTION
PortmasterInfoPackets that were generated from the ALE layer where not freed after they are send to portmaster.
This caused significant memory leak. Since they are info only packets they are not saved in cache and they should bee freed immediately after they are send to portmaster.


Note: Changes in `classifySingle` are not tested thoroughly. It seemed like an too obvious memory leaks.
